### PR TITLE
Include templates and static files to pypi build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,12 @@ include-package-data = true
 [tool.setuptools.packages.find]
 include = ["netbox_diagram*"]
 
+[tool.setuptools.package-data]
+"netbox_diagram" = [
+    "templates/**/*",
+    "static/**/*"
+]
+
 [tool.ruff]
 exclude = [
     "netbox_diagram/migrations",


### PR DESCRIPTION
Include templates and static files to pypi build

Atm templates and static files are not included in pypi.
This PR fixes this.